### PR TITLE
Update AzuraCast button label

### DIFF
--- a/azuracast-embed.js
+++ b/azuracast-embed.js
@@ -211,7 +211,7 @@
     const toggle = document.createElement('button');
     toggle.id = TOGGLE_ID;
     toggle.type = 'button';
-    toggle.textContent = 'Play Neon Drift Garage';
+    toggle.textContent = 'Play AHPP Underground Manager';
     toggle.setAttribute('aria-controls', OVERLAY_ID);
     toggle.setAttribute('aria-expanded', 'false');
 


### PR DESCRIPTION
## Summary
- update the AzuraCast overlay toggle button text to read "Play AHPP Underground Manager"

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ca28232ff08323a8308592fcbc5fd8