### PR TITLE
Hide vendor and race terminal help after first use

### DIFF
--- a/index.html
+++ b/index.html
@@ -142,7 +142,7 @@
       <div class="panel" id="shopPanel">
         <h3>Parts Vendor</h3>
         <div id="modList" class="mod-list"></div>
-        <div class="panel-note">Stand at the vendor & press <b>Action</b> (<code>E</code>) to toggle this UI.</div>
+        <div class="panel-note" id="partsHelp">Stand at the vendor & press <b>Action</b> (<code>E</code>) to toggle this UI.</div>
       </div>
       <div class="panel" id="sellPanel">
         <h3>Race Terminal</h3>


### PR DESCRIPTION
## Summary
- track hint visibility in saved state
- hide the parts vendor and race terminal help text after they are used once

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ca274edcd4832386636eeafe3bcef6