### PR TITLE
Improve layout scaling and vendor UI

### DIFF
--- a/game.js
+++ b/game.js
@@ -307,6 +307,7 @@
   }
 
   updateHelpVisibility();
+  syncVendorUi();
 
   const isTouch = ('ontouchstart' in window) || navigator.maxTouchPoints > 0;
   function bindTouchControls(container) {
@@ -474,6 +475,7 @@
     const saved = JSON.parse(localStorage.getItem(SAVE_KEY) || 'null');
     if (!applySavedState(saved)) { log('No garage save found.'); return; }
     updateHelpVisibility();
+    syncVendorUi();
     save();
     log('Garage save loaded.');
   };
@@ -496,6 +498,7 @@
       const data = JSON.parse(txt);
       applySavedState(data);
       updateHelpVisibility();
+      syncVendorUi();
       save();
       log('Imported garage data.');
     } catch {
@@ -528,7 +531,7 @@
     },
   };
 
-  const GARAGE_W = 420;
+  const GARAGE_W = 480;
   const GARAGE_H = 360;
   const GARAGE_TOP = 260;
 
@@ -650,6 +653,10 @@
   function inside(ax, ay, aw, ah, bx, by, bw, bh) {
     return ax < bx + bw && ax + aw > bx && ay < by + bh && ay + ah > by;
   }
+  function isAtStation(p, station) {
+    if (!p || !station) return false;
+    return inside(p.x, p.y, p.w, p.h, station.x, station.y, station.w, station.h);
+  }
   function dist(ax, ay, bx, by) { const dx = ax - bx, dy = ay - by; return Math.hypot(dx, dy); }
 
   function playerByName(name) {
@@ -684,18 +691,20 @@
       inventory: { ...p.inventory },
     });
 
-    if (inside(p.x, p.y, p.w, p.h, STATIONS.parts.x, STATIONS.parts.y, STATIONS.parts.w, STATIONS.parts.h)) {
+    if (isAtStation(p, STATIONS.parts)) {
       state.shopOpen = state.shopOpen === who ? null : who;
       state.raceOpen = false;
       log('You toggled the Parts Vendor.');
       dismissHint('parts');
-      if (state.shopOpen) { generateModStock(); renderPartsShop(); }
+      if (state.shopOpen) { generateModStock(); }
+      syncVendorUi();
       return;
     }
-    if (inside(p.x, p.y, p.w, p.h, STATIONS.race.x, STATIONS.race.y, STATIONS.race.w, STATIONS.race.h)) {
+    if (isAtStation(p, STATIONS.race)) {
       const sold = sellAll(p);
       if (sold > 0) { log(`You banked ${formatCredits(sold)} in race winnings.`); state.raceOpen = true; state.shopOpen = null; }
       else { log('You have no completed builds to race.'); state.raceOpen = true; state.shopOpen = null; }
+      syncVendorUi();
       dismissHint('race');
       return;
     }
@@ -916,11 +925,26 @@
     }
   }
 
+  function syncVendorUi() {
+    const open = state.shopOpen === 'P1';
+    if (shopPanel) {
+      shopPanel.classList.toggle('panel-hidden', !open);
+      shopPanel.setAttribute('aria-hidden', open ? 'false' : 'true');
+    }
+    if (modListEl) {
+      if (open) {
+        renderPartsShop();
+      } else {
+        modListEl.innerHTML = '';
+      }
+    }
+  }
+
   function buyMod(id) {
     const modData = MOD_CATALOG.find(m => m.id === id);
     if (!modData || !modStock.has(id)) { log('Part not available.'); return; }
     const target = state.p1;
-    if (state.shopOpen !== 'P1' || !inside(target.x, target.y, target.w, target.h, STATIONS.parts.x, STATIONS.parts.y, STATIONS.parts.w, STATIONS.parts.h)) {
+    if (state.shopOpen !== 'P1' || !isAtStation(target, STATIONS.parts)) {
       log('You must be at the Parts Vendor to buy kits.');
       return;
     }
@@ -1398,6 +1422,11 @@
   function update() {
     movePlayer(state.p1, 'KeyW', 'KeyA', 'KeyS', 'KeyD');
     moveCrew(state.p1);
+
+    if (state.shopOpen === 'P1' && !isAtStation(state.p1, STATIONS.parts)) {
+      state.shopOpen = null;
+      syncVendorUi();
+    }
 
     maybeStartStreetEvent();
     maybeSpawnChallenge();

--- a/index.html
+++ b/index.html
@@ -60,7 +60,7 @@
     #gameArea {
       position:relative;
       flex:1;
-      background:#050510;
+      background:#2b0f1a;
       display:flex;
       justify-content:center;
       align-items:flex-start;
@@ -70,7 +70,7 @@
       content:"";
       position:absolute;
       inset:0;
-      background:radial-gradient(circle at top, rgba(31,24,76,0.65) 0%, rgba(5,5,16,0.9) 60%, rgba(2,2,8,1) 100%);
+      background:radial-gradient(circle at top, rgba(70,24,57,0.65) 0%, rgba(30,10,24,0.92) 55%, rgba(21,6,16,0.98) 100%);
       pointer-events:none;
       z-index:0;
     }
@@ -81,7 +81,7 @@
       height:auto;
       display:block;
       image-rendering: pixelated;
-      background:#04040a;
+      background:#360c1b;
       box-shadow:0 26px 52px rgba(0,0,0,0.45);
       border-radius:12px;
     }

--- a/index.html
+++ b/index.html
@@ -57,13 +57,40 @@
     header .savebar input[type=file]{ display:none; }
     .sr-only { position:absolute; width:1px; height:1px; padding:0; margin:-1px; overflow:hidden; clip:rect(0,0,0,0); white-space:nowrap; border:0; }
 
-    #gameArea { position:relative; flex:1; background:#050510; }
-    canvas { width:100%; height:100%; display:block; image-rendering: pixelated; background:#04040a; }
+    #gameArea {
+      position:relative;
+      flex:1;
+      background:#050510;
+      display:flex;
+      justify-content:center;
+      align-items:flex-start;
+      padding:clamp(12px, 3vh, 36px) 0 clamp(48px, 12vh, 140px);
+    }
+    #gameArea::before {
+      content:"";
+      position:absolute;
+      inset:0;
+      background:radial-gradient(circle at top, rgba(31,24,76,0.65) 0%, rgba(5,5,16,0.9) 60%, rgba(2,2,8,1) 100%);
+      pointer-events:none;
+      z-index:0;
+    }
+    canvas {
+      position:relative;
+      z-index:1;
+      width:min(1280px, 100%);
+      height:auto;
+      display:block;
+      image-rendering: pixelated;
+      background:#04040a;
+      box-shadow:0 26px 52px rgba(0,0,0,0.45);
+      border-radius:12px;
+    }
 
     .window {
       position:absolute;
-      top:14px;
+      top:clamp(18px, 5vh, 52px);
       left:50%;
+      z-index:2;
       transform:translateX(-50%);
       display:flex;
       align-items:flex-start;
@@ -83,6 +110,15 @@
       max-height:min(78vh, 620px);
       box-shadow:0 0 18px rgba(0,255,255,0.2);
       pointer-events:auto;
+      transition:opacity .22s ease, transform .22s ease;
+    }
+    .panel.panel-hidden {
+      opacity:0;
+      pointer-events:none;
+      transform:translateY(-18px);
+    }
+    .panel.panel-hidden:not(.events-panel) {
+      display:none;
     }
     .panel h3 { margin:0 0 10px 0; font-size:17px; color:#63e7ff; text-transform:uppercase; letter-spacing:0.12em; }
     .panel .row { display:flex; align-items:center; justify-content:space-between; gap:8px; margin:8px 0; }


### PR DESCRIPTION
## Summary
- keep the playfield canvas at its native aspect while letting the background fill the viewport
- widen the central garage grid to give bays a bit more breathing room
- toggle the parts vendor panel based on proximity so it closes automatically when you walk away

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68caedc140e08323b4295569a67e3e36