### PR TITLE
Add developer toolbar with reset and boost actions

### DIFF
--- a/game.js
+++ b/game.js
@@ -320,6 +320,9 @@
   const btnExport = document.getElementById('btnExport');
   const btnImport = document.getElementById('btnImport');
   const fileImport = document.getElementById('fileImport');
+  const btnDevReset = document.getElementById('btnDevReset');
+  const btnDevFunds = document.getElementById('btnDevFunds');
+  const btnDevFinish = document.getElementById('btnDevFinish');
   const shopPanel = document.getElementById('shopPanel');
   const sellPanel = document.getElementById('sellPanel');
   const partsHelp = document.getElementById('partsHelp');
@@ -549,6 +552,41 @@
       log('Failed to import data.');
     }
   };
+
+  if (btnDevReset) {
+    btnDevReset.addEventListener('click', () => {
+      if (!confirm('Reset all progress and reload the garage?')) return;
+      try {
+        localStorage.removeItem(SAVE_KEY);
+      } catch (err) {
+        console.warn('Unable to clear save key', err);
+      }
+      location.reload();
+    });
+  }
+
+  if (btnDevFunds) {
+    btnDevFunds.addEventListener('click', () => {
+      const bonus = 10000;
+      const current = Math.max(0, Number(state.p1.credits) || 0);
+      state.p1.credits = current + bonus;
+      log(`Dev boost: Added ${formatCredits(bonus)} to your wallet.`);
+      save();
+    });
+  }
+
+  if (btnDevFinish) {
+    btnDevFinish.addEventListener('click', () => {
+      let completed = 0;
+      for (const bay of state.bays) {
+        if (!bay || !bay.build) continue;
+        bay.build.progressMs = bay.build.installMs;
+        completed += 1;
+      }
+      log(`Dev boost: Marked ${completed} build${completed === 1 ? '' : 's'} as complete.`);
+      save();
+    });
+  }
   // ---------- WORLD LAYOUT ----------
   const cv = document.getElementById('game');
   const ctx = cv.getContext('2d');

--- a/index.html
+++ b/index.html
@@ -56,6 +56,27 @@
     header button:hover { color:#fff; border-color:rgba(241,165,18,0.75); box-shadow:0 0 16px rgba(241,165,18,0.4); background:rgba(221,65,17,0.75); }
     header .savebar { display:flex; gap:8px; align-items:center; margin-left:auto; }
     header .savebar input[type=file]{ display:none; }
+    .devbar {
+      display:flex;
+      gap:6px;
+      flex-wrap:wrap;
+      align-items:center;
+      margin-left:8px;
+      padding-left:12px;
+      border-left:1px solid rgba(241,165,18,0.3);
+    }
+    .devbar button {
+      border:1px dashed rgba(161,212,177,0.65);
+      background:rgba(43,175,144,0.18);
+      color:#a1d4b1;
+      box-shadow:0 0 8px rgba(43,175,144,0.22);
+    }
+    .devbar button:hover {
+      border-style:solid;
+      color:#fff;
+      background:rgba(43,175,144,0.32);
+      box-shadow:0 0 12px rgba(161,212,177,0.35);
+    }
     .sr-only { position:absolute; width:1px; height:1px; padding:0; margin:-1px; overflow:hidden; clip:rect(0,0,0,0); white-space:nowrap; border:0; }
 
     #gameArea {
@@ -224,6 +245,11 @@
       <button id="btnImport" title="Import save file">Import</button>
       <label for="fileImport" class="sr-only">Import save file</label>
       <input id="fileImport" type="file" accept="application/json" title="Import save file" />
+    </div>
+    <div class="devbar" id="devTools">
+      <button id="btnDevReset" title="Clear all local progress and reload">Reset Progress</button>
+      <button id="btnDevFunds" title="Grant bonus credits for testing">+10k Credits</button>
+      <button id="btnDevFinish" title="Complete installs currently in progress">Finish Builds</button>
     </div>
     <div class="hint">The Garage persists even when you log off. Overheated bays must be cleared for $250. Fill the spotlight in the plaza to recruit rare crew.</div>
   </header>


### PR DESCRIPTION
## Summary
- add a small developer toolbar in the header with reset, bonus credits, and finish-builds helpers
- hook the new buttons up to local state so saves can be wiped, credits boosted, and installs completed for testing

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cb57f405048323817bf00350482f5e