### PR TITLE
Prevent save during reset

### DIFF
--- a/game.js
+++ b/game.js
@@ -295,7 +295,10 @@
     if (!MODS[player.selected]) player.selected = DEFAULT_MOD;
   }
 
+  let skipSaving = false;
+
   function save() {
+    if (skipSaving) return;
     const minimal = JSON.parse(JSON.stringify({
       payoutMult: state.payoutMult,
       installMult: state.installMult,
@@ -556,11 +559,13 @@
   if (btnDevReset) {
     btnDevReset.addEventListener('click', () => {
       if (!confirm('Reset all progress and reload the garage?')) return;
+      skipSaving = true;
       try {
         localStorage.removeItem(SAVE_KEY);
       } catch (err) {
         console.warn('Unable to clear save key', err);
       }
+      window.removeEventListener('beforeunload', save);
       location.reload();
     });
   }


### PR DESCRIPTION
## Summary
- guard the save routine so it skips writes when a reset is in progress
- stop triggering the beforeunload save during a reset to avoid recreating cleared data

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cb5e849a7883239ccb283ce60b0f70