### PR TITLE
Fix apostrophe in guide hint text

### DIFF
--- a/game.js
+++ b/game.js
@@ -124,7 +124,7 @@
     },
     {
       title: 'Getting Around',
-      text: 'I'''ll give you a few hints since you must have hit your head... Use WASD (or the touch controls) to move. Visit the Parts Vendor to stock up, then head into your bays to install mods.',
+    text: "I'll give you a few hints since you must have hit your head... Use WASD (or the touch controls) to move. Visit the Parts Vendor to stock up, then head into your bays to install mods.",
     },
     {
       title: 'Cash Out & Events',


### PR DESCRIPTION
## Summary
- escape the apostrophe in the guide hint text so the script parses correctly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cb60ad97008323a1f245c5582fec76