### PR TITLE
Fix typo in Ange intro text

### DIFF
--- a/game.js
+++ b/game.js
@@ -121,7 +121,7 @@
   const GUIDE_STEPS = [
     {
       title: 'Meet Ange',
-      text: "Hey there! I'm Ange. Weird, you we're just laying on the floor when I came in... do you even know your name? Your Lee in Lee's Garage! You build some of the hottest cars on the street!",
+      text: "Hey there! I'm Ange. Weird, you were just laying on the floor when I came in... do you even know your name? Your Lee in Lee's Garage! You build some of the hottest cars on the street!",
     },
     {
       title: 'Getting Around',


### PR DESCRIPTION
## Summary
- correct the misspelling of "were" in Ange's introductory dialogue

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cb650ee8648323a99a96576569edb1