### PR TITLE
Fix bay tooltip layering and alignment

### DIFF
--- a/game.js
+++ b/game.js
@@ -888,8 +888,10 @@
     } else {
       txt = 'Empty bay';
     }
-    tooltip.style.left = (p.x + p.w / 2) + 'px';
-    tooltip.style.top = (p.y) + 'px';
+    const anchorX = bay ? bay.x + bay.w / 2 : p.x + p.w / 2;
+    const anchorY = bay ? bay.y + 8 : p.y;
+    tooltip.style.left = anchorX + 'px';
+    tooltip.style.top = anchorY + 'px';
     tooltip.textContent = txt;
     tooltip.style.opacity = 1;
     clearTimeout(showTooltip._t);

--- a/index.html
+++ b/index.html
@@ -216,7 +216,7 @@
     }
     .evt { padding:4px 0; border-bottom:1px dashed rgba(241,165,18,0.3); }
 
-    #tooltip { position:absolute; pointer-events:none; background:rgba(71,16,32,0.92); color:#fbe6c0; padding:6px 8px; border-radius:4px; font-size:12px; transform:translate(-50%, -140%); opacity:0; transition:opacity .08s; white-space:nowrap; border:1px solid rgba(241,165,18,0.6); box-shadow:0 0 8px rgba(221,65,17,0.4); }
+    #tooltip { position:absolute; pointer-events:none; background:rgba(71,16,32,0.92); color:#fbe6c0; padding:6px 8px; border-radius:4px; font-size:12px; transform:translate(-50%, -140%); opacity:0; transition:opacity .08s; white-space:nowrap; border:1px solid rgba(241,165,18,0.6); box-shadow:0 0 8px rgba(221,65,17,0.4); z-index:20; }
 
     footer {
       background: linear-gradient(135deg, rgba(140,0,39,0.92), rgba(43,175,144,0.3));


### PR DESCRIPTION
## Summary
- Ensure the active install tooltip is layered above the canvas background
- Anchor install tooltip positioning to the active bay slot instead of the player

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cb66df267c8323abf05c4a041362c7