### PR TITLE
Revise header styling and disable save/load features

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,52 +16,60 @@
     }
     #wrap { display:flex; flex-direction:column; height:100%; }
     header {
-      background: linear-gradient(135deg, #f1a512, #dd4111 55%, #8c0027 100%);
-      color:#fff7e8;
-      padding:10px 14px;
+      background: linear-gradient(145deg, rgba(56,18,28,0.95), rgba(163,42,38,0.78) 55%, rgba(249,148,60,0.68) 100%);
+      color:#fff9f3;
+      padding:14px clamp(14px, 3vw, 28px);
       font-weight:600;
+      font-family:'Segoe UI', Tahoma, sans-serif;
+      font-size:clamp(15px, 1.4vw, 18px);
+      letter-spacing:0.01em;
       display:flex;
       align-items:center;
-      gap:12px;
+      gap:16px;
       flex-wrap:wrap;
-      box-shadow:0 0 24px rgba(221,65,17,0.32);
-      border-bottom:1px solid rgba(241,165,18,0.5);
+      box-shadow:0 0 26px rgba(221,65,17,0.32);
+      border-bottom:1px solid rgba(241,165,18,0.45);
+      text-shadow:0 1px 3px rgba(22,6,13,0.55);
     }
     header .pill {
-      background: rgba(140, 0, 39, 0.65);
-      padding:6px 10px;
+      background: rgba(16, 8, 14, 0.32);
+      padding:8px 14px;
       border-radius:999px;
-      border:1px solid rgba(241,165,18,0.45);
-      box-shadow:0 0 10px rgba(221,65,17,0.3);
-      color:#ffeccc;
+      border:1px solid rgba(255, 228, 179, 0.55);
+      box-shadow:0 0 14px rgba(22, 8, 18, 0.45);
+      color:#fff5d6;
+      font-size:0.95em;
+      letter-spacing:0.04em;
     }
     header .hint {
       opacity:.9;
       font-weight:400;
       color:#a1d4b1;
       flex-basis:100%;
-      margin-top:4px;
+      margin-top:6px;
+      text-shadow:none;
+      font-size:clamp(13px, 1.1vw, 15px);
     }
     header button {
       border:1px solid rgba(241,165,18,0.45);
-      background: rgba(43, 15, 26, 0.85);
+      background: rgba(32, 12, 21, 0.85);
       color:#fbe6c0;
       border-radius:999px;
-      padding:6px 14px;
+      padding:8px 18px;
       cursor:pointer;
       text-transform:uppercase;
       font-weight:700;
-      box-shadow:0 0 12px rgba(221,65,17,0.35);
+      font-size:0.85em;
+      box-shadow:0 0 14px rgba(221,65,17,0.35);
     }
     header button:hover { color:#fff; border-color:rgba(241,165,18,0.75); box-shadow:0 0 16px rgba(241,165,18,0.4); background:rgba(221,65,17,0.75); }
-    header .savebar { display:flex; gap:8px; align-items:center; margin-left:auto; }
-    header .savebar input[type=file]{ display:none; }
+    header .hint, header .pill { filter:none; }
     .devbar {
       display:flex;
       gap:6px;
       flex-wrap:wrap;
       align-items:center;
-      margin-left:8px;
+      margin-left:auto;
       padding-left:12px;
       border-left:1px solid rgba(241,165,18,0.3);
     }
@@ -275,20 +283,12 @@
     <div class="pill" id="p1money">Credits: $0</div>
     <div class="pill" id="p1hud">Parts: — | Builds: —</div>
     <button id="toggleEvents" title="Toggle Street Feed (H)">Street Feed</button>
-    <div class="savebar">
-      <button id="btnSave" title="Save to browser (Autosaves too)">Save</button>
-      <button id="btnLoad" title="Load from browser">Load</button>
-      <button id="btnExport" title="Download save file">Export</button>
-      <button id="btnImport" title="Import save file">Import</button>
-      <label for="fileImport" class="sr-only">Import save file</label>
-      <input id="fileImport" type="file" accept="application/json" title="Import save file" />
-    </div>
     <div class="devbar" id="devTools">
       <button id="btnDevReset" title="Clear all local progress and reload">Reset Progress</button>
       <button id="btnDevFunds" title="Grant bonus credits for testing">+10k Credits</button>
       <button id="btnDevFinish" title="Complete installs currently in progress">Finish Builds</button>
     </div>
-    <div class="hint">The Garage persists even when you log off. If a tune goes bad and the engine blows, cover 150% of that upgrade's cost to get the car out. Fill the spotlight in the plaza to recruit rare crew.</div>
+    <div class="hint">Keep your crew sharp and the bays busy. If a tune goes bad and the engine blows, cover 150% of that upgrade's cost to get the car out. Fill the spotlight in the plaza to recruit rare crew.</div>
     <div id="eventBanner" class="event-banner" role="status" aria-live="polite" aria-hidden="true"></div>
   </header>
   <div id="gameArea">


### PR DESCRIPTION
## Summary
- restyle the header for improved readability with larger typography and refined colors
- remove the manual save, load, import, and export controls from the UI
- disable persistence hooks in the game script while keeping developer tools intact

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cb6dbb898c8323a6792293830a5a0b