### PR TITLE
Allow game area glow to extend beyond layout bounds

### DIFF
--- a/index.html
+++ b/index.html
@@ -99,7 +99,7 @@
     #gameArea::before {
       content:"";
       position:absolute;
-      inset:0;
+      inset:-8% -8% -18% -8%;
       background:radial-gradient(circle at top, rgba(70,24,57,0.65) 0%, rgba(30,10,24,0.92) 55%, rgba(21,6,16,0.98) 100%);
       pointer-events:none;
       z-index:0;


### PR DESCRIPTION
## Summary
- extend the ::before pseudo-element on #gameArea so the radial glow can overflow the layout container

## Testing
- no automated tests were run

------
https://chatgpt.com/codex/tasks/task_e_68cb72370b9c832384206448cd3bc7f8