### PR TITLE
Disable mobile double-tap zoom

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
   <title>AHPP Underground Garage Tycoon</title>
   <style>
     html, body {
@@ -13,6 +13,7 @@
       font-family: 'Courier New', monospace;
       color: #fbe6c0;
       letter-spacing: 0.03em;
+      touch-action: manipulation;
     }
     #wrap { display:flex; flex-direction:column; height:100%; }
     header {
@@ -114,6 +115,7 @@
       background:#360c1b;
       box-shadow:0 26px 52px rgba(0,0,0,0.45);
       border-radius:12px;
+      touch-action:manipulation;
     }
 
     .window {


### PR DESCRIPTION
## Summary
- prevent mobile zoom gestures by disabling viewport scaling
- hint browsers to treat taps as direct interactions on the page and canvas

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cb74350630832392cd256ba35d0582