### PR TITLE
Add header help overlay and remove footer controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -255,18 +255,6 @@
     }
     #tooltip { position:absolute; pointer-events:none; background:rgba(71,16,32,0.92); color:#fbe6c0; padding:6px 8px; border-radius:4px; font-size:12px; transform:translate(-50%, -140%); opacity:0; transition:opacity .08s; white-space:nowrap; border:1px solid rgba(241,165,18,0.6); box-shadow:0 0 8px rgba(221,65,17,0.4); z-index:20; }
 
-    footer {
-      background: linear-gradient(135deg, rgba(140,0,39,0.92), rgba(43,175,144,0.3));
-      color:#fbe6c0;
-      padding:10px 14px;
-      font-size:14px;
-      display:flex;
-      gap:14px;
-      flex-wrap:wrap;
-      border-top:1px solid rgba(241,165,18,0.35);
-    }
-    footer code { background:#471020; color:#fce2b6; padding:2px 6px; border-radius:6px; }
-
     .touch-controls { position:absolute; bottom:clamp(20px, 8vh, 96px); display:flex; align-items:center; gap:24px; z-index:10; }
     .touch-controls button { touch-action:none; user-select:none; font-size:14px; font-weight:700; display:flex; align-items:center; justify-content:center; padding:0; color:#fbe6c0; background:rgba(71,16,32,0.88); border:1px solid rgba(241,165,18,0.45); border-radius:12px; width:84px; height:56px; box-shadow:0 0 12px rgba(221,65,17,0.35); }
     .touch-controls button:active { box-shadow:0 0 16px rgba(241,165,18,0.45); border-color:rgba(241,165,18,0.7); color:#fff; }
@@ -285,6 +273,7 @@
     <div class="pill" id="p1money">Credits: $0</div>
     <div class="pill" id="p1hud">Parts: — | Builds: —</div>
     <button id="toggleEvents" title="Toggle Street Feed (H)">Street Feed</button>
+    <button id="btnHelp" title="Show controls guide">Help</button>
     <div class="devbar" id="devTools">
       <button id="btnDevReset" title="Clear all local progress and reload">Reset Progress</button>
       <button id="btnDevFunds" title="Grant bonus credits for testing">+10k Credits</button>
@@ -320,14 +309,6 @@
       </div>
     </div>
   </div>
-  <footer>
-    <div>
-      <b>Controls:</b> Use <code>WASD</code> to walk, <code>1–0</code> to select part, <code>Q</code> to swap parts, and <code>E</code> to work a bay. Press <code>H</code> to toggle the Street Feed.
-    </div>
-    <div>
-      Install mods in your own bays. If a build blows its engine during tuning, pay 150% of the upgrade's cost to settle up and release it. Hype the plaza spotlight to recruit legendary crew with powerful perks.
-    </div>
-  </footer>
 </div>
 
 <script src="game.js"></script>


### PR DESCRIPTION
## Summary
- add a Help button to the header that replays Ange's controls guide on demand
- remove the footer instructions now that the refresher lives in the guide overlay

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cb75e2e1288323af8498e397f433ae