### PR TITLE
Prevent game overlay from covering header

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,6 +31,8 @@
       box-shadow:0 0 26px rgba(221,65,17,0.32);
       border-bottom:1px solid rgba(241,165,18,0.45);
       text-shadow:0 1px 3px rgba(22,6,13,0.55);
+      position:relative;
+      z-index:5;
     }
     header .logo {
       height:clamp(38px, 7vw, 64px);
@@ -106,7 +108,7 @@
     #gameArea::before {
       content:"";
       position:absolute;
-      inset:-8% -8% -18% -8%;
+      inset:0 -8% -18% -8%;
       background:radial-gradient(circle at top, rgba(70,24,57,0.65) 0%, rgba(30,10,24,0.92) 55%, rgba(21,6,16,0.98) 100%);
       pointer-events:none;
       z-index:0;


### PR DESCRIPTION
## Summary
- elevate the header above in-game overlays so the top bar is no longer obscured
- confine the in-game lighting mask to start below the header to avoid the mid-screen cut-off effect

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d321e1155c8323bce12681057c41b3