### PR TITLE
Enlarge central Lee's Garage logo

### DIFF
--- a/game.js
+++ b/game.js
@@ -1526,20 +1526,23 @@
 
     ctx.save();
     ctx.fillStyle = 'rgba(15, 12, 20, 0.75)';
+    const signWidth = 1200;
+    const signHeight = 216;
     const signY = garageFloor.y - 78;
-    ctx.fillRect(WORLD.w / 2 - 220, signY - 40, 440, 82);
+    const signCenterX = WORLD.w / 2;
+    const signTop = signY - signHeight / 2;
+    ctx.fillRect(signCenterX - signWidth / 2, signTop, signWidth, signHeight);
     ctx.strokeStyle = 'rgba(241, 165, 18, 0.5)';
     ctx.lineWidth = 3;
-    ctx.strokeRect(WORLD.w / 2 - 220, signY - 40, 440, 82);
+    ctx.strokeRect(signCenterX - signWidth / 2, signTop, signWidth, signHeight);
     ctx.shadowColor = 'rgba(0, 0, 0, 0.5)';
     ctx.shadowBlur = 18;
-    const signCenterX = WORLD.w / 2;
-    const signCenterY = signY + 4;
+    const signCenterY = signTop + signHeight / 2 + 4;
     if (garageLogoReady) {
       const naturalWidth = Math.max(1, garageLogo.naturalWidth || garageLogo.width || 0);
       const naturalHeight = Math.max(1, garageLogo.naturalHeight || garageLogo.height || 0);
-      const maxLogoWidth = 360;
-      const maxLogoHeight = 56;
+      const maxLogoWidth = 1080;
+      const maxLogoHeight = 168;
       const scale = Math.min(1, maxLogoWidth / naturalWidth, maxLogoHeight / naturalHeight);
       const drawWidth = naturalWidth * scale;
       const drawHeight = naturalHeight * scale;


### PR DESCRIPTION
## Summary
- expand the plaza sign backing so it can showcase a much larger Lee's Garage emblem
- allow the in-game logo rendering to scale up to three times the previous size for greater visibility

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d3279b3e288323a0424c41b95b6e1a